### PR TITLE
fix: autolinking when using Xcode 12

### DIFF
--- a/react-native-simple-toast.podspec
+++ b/react-native-simple-toast.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/vonovak/react-native-simple-toast.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Toast', '~> 4.0.0'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on React-Core directly instead of React. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116