### PR TITLE
fix: Modernize RCTBridgeModule import, for Swift-modules compatibility

### DIFF
--- a/ios/LRDRCTSimpleToast/LRDRCTSimpleToast.m
+++ b/ios/LRDRCTSimpleToast/LRDRCTSimpleToast.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016年 luoruidong. All rights reserved.
 //
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "UIView+Toast.h"
 #import <React/RCTUtils.h>
 


### PR DESCRIPTION
This fixes several compilation errors with "Duplicate interface
definition for class […]" when a project uses Expo 44+, which has
Swift modules.

I don't expect this to be a breaking change. Reportedly, it's safe
to use

  #import <React/*.h>

with React Native 40+; see comment linked below. This project
already uses an import of that form. See the line

  #import <React/RCTUtils.h>

in the same file changed in this commit.

Details:
  https://github.com/expo/expo/issues/15622#issuecomment-997225774