### PR TITLE
Toast.show default duration is added

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ type StylesIOS = {
 ```js
 import Toast from 'react-native-simple-toast';
 
+Toast.show('This is a short toast');
+
 Toast.show('This is a long toast.', Toast.LONG);
 
 Toast.showWithGravity(

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,11 @@ export default {
   CENTER: constantsSource.CENTER,
 
   show(message: string, durationSeconds: number, styles: StylesIOS = {}) {
-    RCTToast.show(message, durationSeconds === undefined ? constantsSource.SHORT : durationSeconds, processColors(styles));
+    RCTToast.show(
+      message,
+      durationSeconds === undefined ? constantsSource.SHORT : durationSeconds,
+      processColors(styles),
+    );
   },
 
   showWithGravity(

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export default {
   CENTER: constantsSource.CENTER,
 
   show(message: string, durationSeconds: number, styles: StylesIOS = {}) {
-    RCTToast.show(message, durationSeconds, processColors(styles));
+    RCTToast.show(message, durationSeconds === undefined ? constantsSource.SHORT : durationSeconds, processColors(styles));
   },
 
   showWithGravity(

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export default {
   show(message: string, durationSeconds: number, styles: StylesIOS = {}) {
     RCTToast.show(
       message,
-      durationSeconds === undefined ? constantsSource.SHORT : durationSeconds,
+      durationSeconds ?? constantsSource.SHORT,
       processColors(styles),
     );
   },


### PR DESCRIPTION
This pull request has a short duration that is set to the default duration.

I am using the package for more projects as a result. also more pages are added. In light of the most recent update, the code is damaged. I therefore am unable to swap out old toast for new toast. This merger will aid in resolving the problem.