### PR TITLE
refactor: remove view controller

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -266,7 +266,7 @@ PODS:
   - React-jsinspector (0.71.12)
   - React-logger (0.71.12):
     - glog
-  - react-native-simple-toast (2.0.1):
+  - react-native-simple-toast (3.0.1):
     - React-Core
     - Toast (~> 4)
   - React-perflogger (0.71.12)
@@ -496,7 +496,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 509cd947c28834614808ce056ee8eb700a0662aa
   React-jsinspector: ec4dcbfb1f4e72f04f826a0301eceee5fa7ca540
   React-logger: 35538accacf2583693fbc3ee8b53e69a1776fcee
-  react-native-simple-toast: ba0299fee44a1b52fcf9669ff11d4a2278c9c9ab
+  react-native-simple-toast: 0c7d14bcad288b5b83ae4b0eea65651b4ca829b0
   React-perflogger: 75b0e25075c67565a830985f3c373e2eae5389e0
   React-RCTActionSheet: a0c3e916b327e297d124d9ebe8b0c721840ee04d
   React-RCTAnimation: 3da7025801d7bf0f8cfd94574d6278d5b82a8b88

--- a/ios/RNSimpleToast.mm
+++ b/ios/RNSimpleToast.mm
@@ -107,24 +107,22 @@ RCT_EXPORT_METHOD(showWithGravityAndOffset:(NSString *)message duration:(double)
     NSString *positionString = RNToastPositionMap[@(position)] ?: CSToastPositionBottom;
     dispatch_async(dispatch_get_main_queue(), ^{
         RNToastViewController *controller = [RNToastViewController new];
-        [controller show:^() {
-            UIView *view = [self getToastView:controller];
-            UIView __weak *weakView = view;
-            RNToastViewController __weak *weakController = controller;
+        [controller show];
+        UIView *view = [self getToastView:controller];
+        UIView __weak *weakView = view;
 
-            UIView *toast = [view toastViewForMessage:msg title:nil image:nil style:style];
+        UIView *toast = [view toastViewForMessage:msg title:nil image:nil style:style];
 
-            void (^completion)(BOOL) = ^(BOOL didTap) {
-                [weakView removeFromSuperview];
-                [weakController hide];
-            };
-            if (!CGPointEqualToPoint(offset, CGPointZero)) {
-                CGPoint centerWithOffset = [self getCenterWithOffset:offset view:view toast:toast position:positionString];
-                [view showToast:toast duration:duration position:[NSValue valueWithCGPoint:centerWithOffset] completion:completion];
-            } else {
-                [view showToast:toast duration:duration position:positionString completion:completion];
-            }
-        }];
+        void (^completion)(BOOL) = ^(BOOL didTap) {
+            [weakView removeFromSuperview];
+            [controller hide];
+        };
+        if (!CGPointEqualToPoint(offset, CGPointZero)) {
+            CGPoint centerWithOffset = [self getCenterWithOffset:offset view:view toast:toast position:positionString];
+            [view showToast:toast duration:duration position:[NSValue valueWithCGPoint:centerWithOffset] completion:completion];
+        } else {
+            [view showToast:toast duration:duration position:positionString completion:completion];
+        }
     });
 }
 
@@ -160,8 +158,8 @@ RCT_EXPORT_METHOD(showWithGravityAndOffset:(NSString *)message duration:(double)
     return CGPointMake(view.bounds.size.width / 2.0, (view.bounds.size.height - (toast.frame.size.height / 2.0)) - bottomPadding);
 }
 
-- (UIView *)getToastView:(UIViewController *)ctrl {
-    UIView *rootView = ctrl.view;
+- (UIView *)getToastView:(RNToastViewController *)ctrl {
+    UIView *rootView = ctrl.toastWindow;
     CGRect bounds = rootView.bounds;
     bounds.size.height -= _kbdHeight;
 

--- a/ios/RNToastViewController.h
+++ b/ios/RNToastViewController.h
@@ -1,8 +1,10 @@
 #import <UIKit/UIKit.h>
 
-@interface RNToastViewController : UIViewController
+@interface RNToastViewController : NSObject
 
-- (void)show:(void (^)(void))completion;
+@property(nonatomic, strong) UIWindow *toastWindow;
+
+- (void)show;
 - (void)hide;
 
 @end

--- a/ios/RNToastViewController.m
+++ b/ios/RNToastViewController.m
@@ -2,16 +2,7 @@
 #import "RNToastViewController.h"
 #import <React/RCTUtils.h>
 
-@interface RNToastViewController ()
-
-@property(nonatomic, strong) UIWindow *toastWindow;
-
-@end
-
 @implementation RNToastViewController
-
-// presenting directly from RCTSharedApplication().keyWindow won't work for Alerts
-// which is why we have our own VC
 
 - (UIWindow *)toastWindow
 {
@@ -29,7 +20,6 @@
         }
         
         if (_toastWindow) {
-            _toastWindow.rootViewController = [UIViewController new];
             _toastWindow.windowLevel = UIWindowLevelAlert + 1;
             _toastWindow.userInteractionEnabled = NO;
         }
@@ -38,10 +28,8 @@
     return _toastWindow;
 }
 
-- (void)show:(void (^)(void))completion {
-    self.modalPresentationStyle = UIModalPresentationOverCurrentContext;
+- (void)show {
     [self.toastWindow setHidden:NO];
-    [self.toastWindow.rootViewController presentViewController:self animated:NO completion:completion];
 }
 
 - (void)hide {


### PR DESCRIPTION
Hello there!

Presenting a `UIViewController` isn't necessary because `UIWindow` extends `UIView`, allowing us to add toasts directly to the `UIWindow`. I've seen a comment that says that a view controller is required for alerts, but I have tested it with alerts, and it works for them as well.

I have kept the previous file name for now, for a better diff.