### PR TITLE
add default value for durationSeconds argument, so that TS allows to call show() with just one argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export default {
   BOTTOM: constantsSource.BOTTOM,
   CENTER: constantsSource.CENTER,
 
-  show(message: string, durationSeconds: number, styles: StylesIOS = {}) {
+  show(message: string, durationSeconds: number = constantsSource.SHORT, styles: StylesIOS = {}) {
     RCTToast.show(
       message,
       durationSeconds ?? constantsSource.SHORT,


### PR DESCRIPTION
Currently, calls like `Toast.show('Message');` are being highlighted as an error, since the second argument is still required, even though PR #51 allowed it to be omitted. Hopefully, this PR fixes this.