### PR TITLE
fix: Bool Error during macOS Catalyst build

### DIFF
--- a/ios/RNSimpleToast.mm
+++ b/ios/RNSimpleToast.mm
@@ -121,7 +121,7 @@ RCT_EXPORT_METHOD(showWithGravityAndOffset:(NSString *)message duration:(double)
         };
         // CSToastManager state is shared among toasts, and is used when toast is shown
         // so modifications to it should happen in the dispatch_get_main_queue block
-        [CSToastManager setTapToDismissEnabled:options[@"tapToDismissEnabled"]];
+        [CSToastManager setTapToDismissEnabled:[options[@"tapToDismissEnabled"] boolValue]];
 
         if (!CGPointEqualToPoint(offset, CGPointZero)) {
             CGPoint centerWithOffset = [self getCenterWithOffset:offset view:view toast:toast position:positionString];


### PR DESCRIPTION
While building for macOS Catalyst, we get an error - Cannot initialize a parameter of type 'BOOL' (aka 'signed char') with an rvalue of type 'id _Nullable'. Fix resolves this issue.   Fixes issue #84 